### PR TITLE
Store triggered status checks in Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ CABOT_PLUGINS_ENABLED=cabot_alert_victorops,<other plugins>
 
 # Configuration
 
-This plugin requries two environment variables:
+This plugin requries the following environment variables to be set:
 ```sh
 VICTOROPS_APP_ID=<your_victorops_app_id>
 VICTOROPS_API_KEY=<your_victorops_api_key>
+VICTOROPS_REDIS_URL=redis://<host>:<port>/<db>
 ```
+
+See the [redis-py docs](https://redis-py.readthedocs.io/en/stable/#redis.Redis.from_url) for more info about the supported URL schemes for Redis.
 
 # Known Issues / TODO
 

--- a/cabot_alert_victorops/models.py
+++ b/cabot_alert_victorops/models.py
@@ -26,7 +26,7 @@ class VictorOpsAlertPlugin(AlertPlugin):
     def send_alert(self, service, users, duty_officers):
         # Redis is used to store existing incidents,
         # so that multiple Celery workers can resolve them
-        r = redis.from_url(env.get('REDIS_URL'))
+        r = redis.from_url(env.get('VICTOROPS_REDIS_URL'))
 
         details = Template(details_template).render(Context({
             'service': service,


### PR DESCRIPTION
This will store triggered status checks in Redis rather than a local dict.

It fixes an issue with multile celery workers where each of them would hold a different state of triggered checks.

